### PR TITLE
Add initial JHU schemas and example

### DIFF
--- a/examples/jhu/full.json
+++ b/examples/jhu/full.json
@@ -1,0 +1,32 @@
+{
+    "title": "The title of the article",
+    "journal-title": "A Terrific Journal",
+    "volume": "2",
+    "issue": "4",
+    "ISSN": "1234-5678,9876-543X",
+    "publisher": "Journal Publisher Inc",
+    "publicationDate": "2018",
+    "abstract": "This is the abstract of the article.",
+    "authors": [
+        {
+            "author": "Bob Author" 
+        },
+        {
+            "author": "Jane Writer",
+            "orcid": "https://orcid.org/1234-5678-9087-4453"
+        }
+    ],
+    "under-embargo": "true",
+    "Embargo-end-date": "2019-01-18",
+    "agent_information": {
+        "name": "Chrome",
+        "version": "704583"
+    },
+    "agreements": {
+        "JScholarship": "This is the text I agreed to",
+        "NIHMS": "http://example.org/policies/nihms.html"
+    },
+    "doi": "10.123/foo.bar.xyz",
+    "journal-NLMTA-ID": "atj",
+    "journal-title-short": "ATJ"
+}

--- a/jhu/common.json
+++ b/jhu/common.json
@@ -1,0 +1,57 @@
+{
+    "title": "JHU common schema",
+    "description": "Enumerates the common properies required by most repositories",
+    "$id": "https://github.com/OA-PASS/metadata-schemas/jhu/common.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "form": {
+            "type": "object",
+            "title": "Publication Details <br><p class='lead text-muted'>Please provide additional information about your article/manuscript below. If DOI was provided in the initial step of the submission, the metadata associated with that DOI was found and used to prepopulatethis form. </p> <p class='lead text-muted'> <i class='glyphicon glyphicon-info-sign'></i> Fields that are not editable were populated using metadata associated with the provided DOI. </p>",
+            "$comment": "These properties are intended to be displayed in an Alpaca form",
+            "properties": {
+                "title": {
+                    "$ref": "global.json#/properties/title"
+                },
+                "journal-title": {
+                    "$ref": "global.json#/properties/journal-title"
+                },
+                "volume": {
+                    "$ref": "global.json#/properties/volume"
+                },
+                "issue": {
+                    "$ref": "global.json#/properties/issue"
+                },
+                "ISSN": {
+                    "$ref": "global.json#/properties/ISSN"
+                },
+                "publisher": {
+                    "$ref": "global.json#/properties/publisher"
+                },
+                "publicationDate": {
+                    "$ref": "global.json#/properties/publicationDate"
+                },
+                "abstract": {
+                    "$ref": "global.json#/properties/abstract"
+                },
+                "authors": {
+                    "$ref": "global.json#/properties/authors"
+                },
+                "under-embargo": {
+                    "$ref": "global.json#/properties/under-embargo"
+                },
+                "Embargo-end-date": {
+                    "$ref": "global.json#/properties/Embargo-end-date"
+                }
+            },
+            "options": {
+                "$ref": "global.json#/options"
+            }
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "#definitions/form"
+        }
+    ]
+}

--- a/jhu/global.json
+++ b/jhu/global.json
@@ -1,0 +1,217 @@
+{
+    "title": "JHU global schema",
+    "description": "Defines all possible metadata fields for PASS deposit",
+    "$id": "https://github.com/OA-PASS/metadata-schemas/jhu/global.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+        "title",
+        "journal-title"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "agreements": {
+            "type": "object",
+            "title": "Agreements to deposit conditions",
+            "description": "Maps repository keys to the text or links containing the agreements accepted by the submitter",
+            "$comment": "This was formerly known as 'embargo', available only for JScholarship metadata",
+            "patternProperties": {
+                "^.+$": {
+                    "type": "string",
+                    "title": "Agreement",
+                    "description": "Text or link agreed to for the given repository key",
+                    "$comment": "Example: {'jScholarship': 'http://example.org/agreementText'}"
+                }
+            }
+        },
+        "abstract": {
+            "type": "string",
+            "title": "Abstract",
+            "description": "The abstract of the article or manuscript being submitted"
+        },
+        "agent_information": {
+            "type": "object",
+            "title": "User agent (browser) information",
+            "description": "Contains the identity and version of the user's browser",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "User agent (browser) name"
+                },
+                "version": {
+                    "type": "string",
+                    "title": "User agent (browser) version"
+                }
+            }
+        },
+        "authors": {
+            "type": "array",
+            "title": "Authors of this article or manuscript",
+            "description": "List of authors and their associated ORCIDS, if available",
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "title": "Author",
+                "properties": {
+                    "author": {
+                        "type": "string",
+                        "title": "Name",
+                        "fieldClass": "body-text col-6 pull-left pl-0"
+                    },
+                    "orcid": {
+                        "type": "string",
+                        "title": "ORCiD",
+                        "fieldClass": "body-text col-6 pull-left pr-0"
+                    }
+                }
+            }
+        },
+        "doi": {
+            "type": "string",
+            "pattern": "^10\\..+?/.+?$",
+            "title": "DOI of article",
+            "description": "The DOI of the individual article or manuscript submitted"
+        },
+        "Embargo-end-date": {
+            "type": "string",
+            "format": "date",
+            "title": "Embargo end date",
+            "description": "Date at which the article or manuscript may be made public"
+        },
+        "journal-NLMTA-ID": {
+            "type": "string",
+            "title": "NTMLA",
+            "description": "NLM identifier for a journal"
+        },
+        "journal-title": {
+            "type": "string",
+            "title": "Journal title",
+            "description": "Title of the journal the individual article or manuscript was submitted to"
+        },
+        "journal-title-short": {
+            "type": "string",
+            "title": "Short journal title",
+            "description": "Short journal title from CrossRef"
+        },
+        "issue": {
+            "type": "string",
+            "title": "Journal issue",
+            "description": "Issue number of the journal this article or manuscript was submitted to"
+        },
+        "ISSN": {
+            "type": "string",
+            "title": "ISSN",
+            "description": "Comma separated ISSN numbers for the journal this article or manuscript was submitted to"
+        },
+        "publisher": {
+            "type": "string",
+            "title": "Publisher",
+            "description": "Publisher of the journal this article or manuscript was submitted to"
+        },
+        "publicationDate": {
+            "format": "string",
+            "title": "Publication Date",
+            "description": "Publication date of the journal or article this manuscript was submitted to",
+            "$comment": "This was formerly date-time format, but that appears too precise for values like 'Summer 2018'"
+        },
+        "title": {
+            "type": "string",
+            "title": "Article / Manuscript Title",
+            "description": "The title of the individual article or manuscript that was submitted"
+        },
+        "under-embargo": {
+            "type": "string",
+            "title": "Under Embargo",
+            "description": "Indicates wither the article or manuscript is under embargo",
+            "$comment": "This should probably be a boolean"
+        },
+        "volume": {
+            "type": "string",
+            "title": "Journal Volume",
+            "description": "journal volume this article or manuscript was published in"
+        }
+    },
+    "options": {
+        "fields": {
+            "title": {
+                "type": "textarea",
+                "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
+                "placeholder": "Enter the manuscript title",
+                "rows": 2,
+                "cols": 100,
+                "hidden": false
+            },
+            "journal-title": {
+                "type": "text",
+                "label": "Journal Title <small class=\"text-muted\">(required)</small>",
+                "placeholder": "Enter the journal title",
+                "hidden": false
+            },
+            "journal-NLMTA-ID": {
+                "type": "text",
+                "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "nlmta"
+            },
+            "volume": {
+                "type": "text",
+                "label": "Volume  <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter the volume",
+                "hidden": false
+            },
+            "issue": {
+                "type": "text",
+                "label": "Issue  <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter issue",
+                "hidden": false
+            },
+            "ISSN": {
+                "type": "text",
+                "label": "ISSN <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "ISSN",
+                "hidden": false
+            },
+            "publisher": {
+                "type": "text",
+                "label": "Publisher <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter the Publisher",
+                "hidden": false
+            },
+            "publicationDate": {
+                "type": "date",
+                "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
+                "hidden": false
+            },
+            "abstract": {
+                "type": "textarea",
+                "label": "Abstract <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter abstract",
+                "fieldClass": "clearfix",
+                "hidden": false
+            },
+            "authors": {
+                "label": "<div class=\"row\"><div class=\"col-6\">Author(s) <small class=\"text-muted\">(optional)</small> </div><div class=\"col-6 p-0\">ORCID(s)</div></div>",
+                "hidden": false
+            },
+            "under-embargo": {
+                "type": "checkbox",
+                "rightLabel": "The material being submitted is published under an embargo.",
+                "fieldClass": "m-0 mt-4",
+                "hidden": false
+            },
+            "Embargo-end-date": {
+                "type": "date",
+                "label": "Embargo End Date",
+                "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
+                "helpersPosition": "above",
+                "placeholder": "dd/mm/yyyy",
+                "validate": true,
+                "inputType": "date",
+                "fieldClass": "date-time-picker",
+                "picker": {
+                    "format": "MM/DD/YY",
+                    "allowInputToggle": true
+                }
+            }
+        }
+    }
+}

--- a/jhu/jscholarship.json
+++ b/jhu/jscholarship.json
@@ -1,0 +1,32 @@
+{
+    "title": "JScholarship schema",
+    "description": "JScholarship-specific metadata requirements",
+    "$id": "https://github.com/OA-PASS/metadata-schemas/jhu/jscholarship.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "form": {
+            "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
+            "type": "object",
+            "required": [
+                "authors"
+            ],
+            "properties": {
+                "authors": {
+                    "$ref": "global.json#/properties/authors"
+                }
+            }
+        },
+        "options": {
+            "$ref": "global.json#/options"
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "global.json#"
+        },
+        {
+            "$ref": "#/definitions/form"
+        }
+    ]
+}

--- a/jhu/nihms.json
+++ b/jhu/nihms.json
@@ -1,0 +1,47 @@
+{
+    "title": "NIHMS schema",
+    "description": "NIHMS-specific metadata requirements",
+    "$id": "https://github.com/OA-PASS/metadata-schemas/jhu/nihms.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "form": {
+            "title": "NIH Manuscript Submission System (NIHMS) <br><p class='lead text-muted'>The following metadata fields will be part of the NIHMS submission.</p>",
+            "type": "object",
+            "required": [
+                "journal-NLMTA-ID"
+            ],
+            "properties": {
+                "journal-NLMTA-ID": {
+                    "$ref": "global.json#/properties/journal-NLMTA-ID"
+                }
+            }
+        },
+        "prerequisites": {
+            "title": "prerequisites",
+            "type": "object",
+            "required": [
+                "authors"
+            ],
+            "properties": {
+                "authors": {
+                    "$ref": "http://localhost:8080/schemas/global.json#/properties/authors"
+                }
+            }
+        },
+        "options": {
+            "$ref": "global.json#/options"
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "global.json#"
+        },
+        {
+            "$ref": "#/definitions/prerequisites"
+        },
+        {
+            "$ref": "#/definitions/form"
+        }
+    ]
+}

--- a/jhu/nihms.json
+++ b/jhu/nihms.json
@@ -8,28 +8,40 @@
         "form": {
             "title": "NIH Manuscript Submission System (NIHMS) <br><p class='lead text-muted'>The following metadata fields will be part of the NIHMS submission.</p>",
             "type": "object",
+            "properties": {
+                "journal-NLMTA-ID": {
+                    "$ref": "global.json#/properties/journal-NLMTA-ID"
+                },
+                "ISSN": {
+                    "$ref": "global.json#/properties/ISSN"
+                }
+            }
+        },
+        "prerequisites": {
+            "anyOf": [
+                {"$ref": "#/definitions/nlmta_present"},
+                {"$ref": "#/definitions/issn_present"}
+            ]
+        },
+        "issn_present": {
+            "type": "object",
+            "required": [
+                "ISSN"
+            ],
+            "properties": {
+                "ISSN": {
+                    "$ref": "global.json#/properties/ISSN"
+                }
+            }
+        },
+        "nlmta_present": {
+            "type": "object",
             "required": [
                 "journal-NLMTA-ID"
             ],
             "properties": {
                 "journal-NLMTA-ID": {
                     "$ref": "global.json#/properties/journal-NLMTA-ID"
-                }
-            }
-        },
-        "prerequisites": {
-            "title": "prerequisites",
-            "type": "object",
-            "required": [
-                "authors",
-                "ISSN"
-            ],
-            "properties": {
-                "authors": {
-                    "$ref": "global.json#/properties/authors"
-                },
-                "ISSN": {
-                    "$ref": "global.json#/properties/ISSN"
                 }
             }
         },

--- a/jhu/nihms.json
+++ b/jhu/nihms.json
@@ -21,12 +21,16 @@
             "title": "prerequisites",
             "type": "object",
             "required": [
-                "authors"
+                "authors",
+                "ISSN"
             ],
             "properties": {
                 "authors": {
-                    "$ref": "http://localhost:8080/schemas/global.json#/properties/authors"
-                }
+                    "$ref": "global.json#/properties/authors"
+                },
+                "ISSN": {
+                    "$ref": "global.json#/properties/ISSN"
+                },
             }
         },
         "options": {

--- a/jhu/nihms.json
+++ b/jhu/nihms.json
@@ -30,7 +30,7 @@
                 },
                 "ISSN": {
                     "$ref": "global.json#/properties/ISSN"
-                },
+                }
             }
         },
         "options": {


### PR DESCRIPTION
Creates an initial metadata schema set for PASS at JHU.  Uses the flat metadata structure as described in the [design doc](https://docs.google.com/document/d/1sLWGZR4kCvQVGv-TA5x8ny-AxL3ChBYNeFYW1eACsDw/edit#heading=h.bz2cwqlhpysc)

Largely reproduces existing metadata fields as-is, with the following notable exceptions:
* The global schema adds a new `agreements` property, which enumerates the various agreement text(s) agreed upon, and the repositories they pertain to.
* Adds validation for DOIs to ensure they are of the form `10.123/foo.bar.z`, rather than, say `doi:10.123...` or `http://dx.doi.org/10.123...`

# How to test
We should probably add tests to validate the schemas upon commit, and validate example data at some point (out of scope for this PR).  In the meantime, please focus on the high-level content of the schemas
* look at the global schema `jhu/global.json` and the example data at  `examples/jhu/full.json`.  Are we happy with the property names?  Is there any opportunity to fix past mistakes?.
* look at the `required` property of the schemas and see if it actually matches the requirements of DS, or the repositories being deposited into.  Note that:
  * The global schema requires `title`, `journal-title`.  Does this reflect the globally required fields for all of PASS?
  * The common schema doesn't claim any specific required fields of its own.
  * The JScholarship schema requires `authors`
  * The NIHMS schema requires `journal-NLMTA-ID` and `ISSN`.

Resolves #1 #2 and #3 