### PR TITLE
Use different algorithm for dereferencing

### DIFF
--- a/lib/jsonschema/analyzer.go
+++ b/lib/jsonschema/analyzer.go
@@ -1,0 +1,165 @@
+package jsonschema
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/xeipuuv/gojsonpointer"
+	"github.com/xeipuuv/gojsonreference"
+)
+
+const refKey = "$ref"
+
+type errs []error
+
+func (e errs) Error() string {
+	return fmt.Sprintf("%s", []error(e))
+}
+
+type ref struct {
+	encounteredAt gojsonpointer.JsonPointer     // The location of the $ref in the schema in which it occurs
+	pointsTo      gojsonreference.JsonReference // The json pointer the $ref points to
+}
+
+// returns the schema URI of the schema the $ref points to
+func (r *ref) pointsIn() string {
+	if r.pointsTo.HasFullUrl {
+		return strings.Split(r.pointsTo.GetUrl().String(), "#")[0]
+	}
+	return ""
+}
+
+type pointer []string
+
+func (p pointer) push(segment string) pointer {
+	return append(p, segment)
+}
+
+func (p pointer) toGojsonPointer() gojsonpointer.JsonPointer {
+	ptr, _ := gojsonpointer.NewJsonPointer(fmt.Sprintf("/%s", strings.Join(p, "/")))
+	return ptr
+}
+
+type schemaAnalyzer struct {
+	doc    Instance
+	refs   []ref
+	errors errs
+}
+
+func (c *schemaAnalyzer) findRefs() error {
+	c._scanObj(nil, c.doc)
+
+	if len(c.errors) > 0 {
+		return c.errors
+	}
+
+	return nil
+}
+
+func (c *schemaAnalyzer) take(filter func(ref) bool) []ref {
+	var keep, taken []ref
+
+	for _, r := range c.refs {
+		switch filter(r) {
+		case true:
+			taken = append(taken, r)
+		case false:
+			keep = append(keep, r)
+		}
+	}
+
+	c.refs = keep
+	return taken
+}
+
+func (c *schemaAnalyzer) peek(filter func(ref) bool) []ref {
+	var matches []ref
+	for _, r := range c.refs {
+		if filter(r) {
+			matches = append(matches, r)
+		}
+	}
+	return matches
+}
+
+func (c *schemaAnalyzer) _scanObj(p pointer, obj map[string]interface{}) {
+	for k, v := range obj {
+		if k == refKey {
+			c._addRef(p, v)
+		} else {
+			c._scan(p.push(k), v)
+		}
+	}
+}
+
+func (c *schemaAnalyzer) _scan(p pointer, something interface{}) {
+	if something == nil {
+		return
+	}
+
+	switch v := something.(type) {
+	case map[string]interface{}:
+		c._scanObj(p, v)
+	case []interface{}:
+		c._scanList(p, v)
+	default:
+	}
+}
+
+func (c *schemaAnalyzer) _scanList(p pointer, list []interface{}) {
+	for i, v := range list {
+		c._scan(p.push(strconv.Itoa(i)), v)
+	}
+}
+
+// we've found a {"$ref": <refContent> }, where <refContent> is hopefully a http URI
+// like "#/path/to/foo" or "whatever.json#/path/to/foo", or "http://example.org/whatever.json#/path/to/foo"
+func (c *schemaAnalyzer) _addRef(p pointer, refContent interface{}) {
+
+	refString, ok := refContent.(string)
+	if !ok {
+		c.errors = append(c.errors,
+			fmt.Errorf("expected to find a string in $ref at %s, instead found %s", p.toGojsonPointer(), refContent))
+		return
+	}
+
+	jsonref, err := gojsonreference.NewJsonReference(refString)
+	if err != nil {
+		c.errors = append(c.errors,
+			errors.Wrapf(err, "could not parse json reference at %s with content %s", p.toGojsonPointer(), refString))
+		return
+	}
+
+	// Ref is of the form foo.json#/path.  So we need to make foo.json absolute by taking the base
+	// of $id
+	if !jsonref.HasFullUrl && jsonref.HasUrlPathOnly && !jsonref.HasFragmentOnly {
+		id, ok := c.doc["$id"]
+		if !ok {
+			c.errors = append(c.errors, fmt.Errorf("found relative reference %s, but doc does not have an ID", jsonref.GetUrl()))
+			return
+		}
+
+		if _, ok := id.(string); !ok {
+			c.errors = append(c.errors, fmt.Errorf("$id is not a string"))
+			return
+		}
+
+		uri, err := url.Parse(id.(string))
+		if err != nil {
+			c.errors = append(c.errors, errors.Wrap(err, "$id is not a well-formed url"))
+			return
+		}
+		uri.Path = path.Join(path.Dir(uri.Path), jsonref.GetUrl().Path)
+
+		absoluteRef, _ := gojsonreference.NewJsonReference(fmt.Sprintf("%s#%s", uri.String(), jsonref.GetUrl().Fragment))
+
+		c.refs = append(c.refs, ref{pointsTo: absoluteRef, encounteredAt: p.toGojsonPointer()})
+		return
+	}
+
+	c.refs = append(c.refs, ref{pointsTo: jsonref, encounteredAt: p.toGojsonPointer()})
+}

--- a/lib/jsonschema/fetch.go
+++ b/lib/jsonschema/fetch.go
@@ -1,0 +1,56 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Fetcher fetches a parsed schema, given a URL.
+// The URL may be unclean (have hash fragments)
+type Fetcher interface {
+	GetSchema(uri *url.URL) (s Instance, ok bool, err error) // Retrieve a schema
+}
+
+// Map is a simple map of schema URIs to schema instances, serving as a static
+// schema Fetcher
+type Map map[string]Instance
+
+// Add an un-parsed schema to the map.  This will parse it, and place it
+// into the map based on the $id present in the schema
+func (m Map) Add(src ...io.Reader) error {
+	for _, reader := range src {
+		schema := make(map[string]interface{})
+		err := json.NewDecoder(reader).Decode(&schema)
+		if err != nil {
+			return errors.Wrapf(err, "could not decode schema instance")
+		}
+
+		i, ok := schema[idKey]
+		if !ok {
+			return fmt.Errorf("schema does not have an $id")
+		}
+
+		id, ok := i.(string)
+		if !ok {
+			return fmt.Errorf("$id is not a string")
+		}
+
+		log.Printf("Loaded schema %s", id)
+		m[id] = schema
+	}
+
+	return nil
+}
+
+// GetSchema retrieves a schema from the map, given a possibly unclean URL.
+func (m Map) GetSchema(url *url.URL) (Instance, bool, error) {
+	normalized := strings.Split(url.String(), "#")[0]
+	s, ok := m[normalized]
+	return s, ok, nil
+}

--- a/lib/jsonschema/fetch_test.go
+++ b/lib/jsonschema/fetch_test.go
@@ -1,0 +1,78 @@
+package jsonschema_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/OA-PASS/metadata-schemas/lib/jsonschema"
+	"github.com/go-test/deep"
+)
+
+func TestMapSchemaAddGet(t *testing.T) {
+	id1 := "http://example.org/foo"
+	id2 := "http://example.org/bar"
+
+	data := []struct {
+		id   string
+		json string
+	}{
+		{id1, fmt.Sprintf(`{ "$id": "%s", "foo": "bar"}`, id1)},
+		{id2, fmt.Sprintf(`{ "$id": "%s", "foo": "bar"}`, id2)},
+	}
+
+	m := jsonschema.Map(make(map[string]jsonschema.Instance))
+	err := m.Add(strings.NewReader(data[0].json), strings.NewReader(data[1].json))
+	if err != nil {
+		t.Fatalf("Adding schema produced an error %+v", err)
+	}
+
+	if len(m) != 2 {
+		t.Fatalf("Should have mapped two schemas")
+	}
+
+	for _, d := range data {
+		_, ok := m[d.id]
+		if !ok {
+			t.Fatalf("Did not map id %s", d.id)
+		}
+
+		url, _ := url.Parse(d.id)
+
+		roundtripped, ok, err := m.GetSchema(url)
+		if !ok || err != nil {
+			t.Errorf("Could not get schema %s", d.id)
+		}
+
+		original := jsonschema.Instance(make(map[string]interface{}))
+		_ = json.Unmarshal([]byte(d.json), &original)
+
+		diffs := deep.Equal(roundtripped, original)
+		if len(diffs) > 0 {
+			t.Fatalf("Differences found between roundtripped and original json: %s", diffs)
+		}
+	}
+
+}
+
+func TestMapSchemaErrors(t *testing.T) {
+	cases := map[string]string{
+		"oId":          `{"foo": "bar"}`,
+		"idNotAString": `{"$id": {"foo": "bar"}}`,
+		"badJSON":      "{{--,",
+	}
+
+	m := jsonschema.Map(make(map[string]jsonschema.Instance))
+
+	for name, json := range cases {
+		json := json
+		t.Run(name, func(t *testing.T) {
+			err := m.Add(strings.NewReader(json))
+			if err == nil {
+				t.Fatalf("Should have thrown an error")
+			}
+		})
+	}
+}

--- a/lib/jsonschema/sort.go
+++ b/lib/jsonschema/sort.go
@@ -105,7 +105,7 @@ func findDeps(schema Instance) (map[string]bool, error) {
 	}
 
 	for _, ref := range analyzer.refs {
-		if uri := ref.schemaURI(); uri != "" {
+		if uri := ref.pointsIn(); uri != "" {
 			deps[uri] = true
 		}
 	}

--- a/lib/web/service.go
+++ b/lib/web/service.go
@@ -40,12 +40,6 @@ func (s *SchemaService) Schemas(r *Request) ([]jsonschema.Instance, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not sort schemas")
 	}
-	for _, schema := range sorted {
-		err := schema.Dereference(s.SchemaFetcher)
-		if err != nil {
-			return nil, errors.Wrapf(err, "could not dereference schema %s", schema.ID())
-		}
-	}
 
-	return sorted, nil
+	return sorted, jsonschema.Dereference(s.SchemaFetcher, sorted...)
 }


### PR DESCRIPTION
The previous algorithm was too simple.  It is necessary to establish
a global dereferencing context in order to detect cycles, as well as
use an iterative process for dereferencing local references that might
be deeply nested, but acyclic.