### PR TITLE
add pubType to issns

### DIFF
--- a/examples/jhu/full.json
+++ b/examples/jhu/full.json
@@ -6,7 +6,7 @@
     "issns": [
         {
             "issn": "1234-5678",
-            "pubType": "online"
+            "pubType": "Online"
         },
         {
             "issn": "1234-5678x"

--- a/examples/jhu/full.json
+++ b/examples/jhu/full.json
@@ -3,13 +3,21 @@
     "journal-title": "A Terrific Journal",
     "volume": "2",
     "issue": "4",
-    "ISSN": "1234-5678,9876-543X",
+    "issns": [
+        {
+            "issn": "1234-5678",
+            "pubType": "online"
+        },
+        {
+            "issn": "1234-5678x"
+        }
+    ],
     "publisher": "Journal Publisher Inc",
     "publicationDate": "2018",
     "abstract": "This is the abstract of the article.",
     "authors": [
         {
-            "author": "Bob Author" 
+            "author": "Bob Author"
         },
         {
             "author": "Jane Writer",

--- a/jhu/common.json
+++ b/jhu/common.json
@@ -22,8 +22,8 @@
                 "issue": {
                     "$ref": "global.json#/properties/issue"
                 },
-                "ISSN": {
-                    "$ref": "global.json#/properties/ISSN"
+                "issns": {
+                    "$ref": "global.json#/properties/issns"
                 },
                 "publisher": {
                     "$ref": "global.json#/properties/publisher"

--- a/jhu/global.json
+++ b/jhu/global.json
@@ -98,10 +98,28 @@
             "title": "Journal issue",
             "description": "Issue number of the journal this article or manuscript was submitted to"
         },
-        "ISSN": {
-            "type": "string",
-            "title": "ISSN",
-            "description": "Comma separated ISSN numbers for the journal this article or manuscript was submitted to"
+        "issns": {
+            "type": "array",
+            "title": "ISSN information for the manuscript's journal",
+            "description": "List of ISSN numbers with optional publication type",
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "title": "ISSN info",
+                "properties": {
+                    "issn": {
+                        "type": "string",
+                        "title": "ISSN ",
+                        "fieldClass": "body-text col-6 pull-left pl-0"
+                    },
+                    "pubType": {
+                        "type": "string",
+                        "title": "publication type",
+                        "fieldClass": "body-text col-6 pull-left pr-0",
+                        "enum": ["print", "online"]
+                    }
+                }
+            }
         },
         "publisher": {
             "type": "string",
@@ -164,10 +182,8 @@
                 "placeholder": "Enter issue",
                 "hidden": false
             },
-            "ISSN": {
-                "type": "text",
-                "label": "ISSN <small class=\"text-muted\">(optional)</small>",
-                "placeholder": "ISSN",
+            "issns": {
+                "label": "<div class=\"row\"><div class=\"col-6\">ISSN(s) <small class=\"text-muted\">(optional)</small> </div><div class=\"col-6 p-0\">publication type(s)</div></div>",
                 "hidden": false
             },
             "publisher": {

--- a/jhu/global.json
+++ b/jhu/global.json
@@ -116,7 +116,7 @@
                         "type": "string",
                         "title": "publication type",
                         "fieldClass": "body-text col-6 pull-left pr-0",
-                        "enum": ["print", "online"]
+                        "enum": ["Print", "Online"]
                     }
                 }
             }

--- a/jhu/nihms.json
+++ b/jhu/nihms.json
@@ -12,8 +12,8 @@
                 "journal-NLMTA-ID": {
                     "$ref": "global.json#/properties/journal-NLMTA-ID"
                 },
-                "ISSN": {
-                    "$ref": "global.json#/properties/ISSN"
+                "issns": {
+                    "$ref": "global.json#/properties/issns"
                 }
             }
         },
@@ -26,11 +26,11 @@
         "issn_present": {
             "type": "object",
             "required": [
-                "ISSN"
+                "issns"
             ],
             "properties": {
-                "ISSN": {
-                    "$ref": "global.json#/properties/ISSN"
+                "issns": {
+                    "$ref": "global.json#/properties/issns"
                 }
             }
         },


### PR DESCRIPTION
ISSNs is now a JSON list, rather than a comma delimited string.  Entries
contain an issn field and a pubType field, which takes enumerated values

Resolves #14 