### PR TITLE
Add required $schema property to jhu global schema

### DIFF
--- a/examples/jhu/full.json
+++ b/examples/jhu/full.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://oa-pass.github.io/metadata-schemas/jhu/global.json",
     "title": "The title of the article",
     "journal-title": "A Terrific Journal",
     "volume": "2",

--- a/jhu/global.json
+++ b/jhu/global.json
@@ -5,11 +5,17 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
+        "$schema",
         "title",
         "journal-title"
     ],
     "additionalProperties": false,
     "properties": {
+        "$schema": {
+            "type": "string",
+            "title": "JSON schema",
+            "description": "The JSON schema that applies to the resulting metadata blob"
+        },
         "agreements": {
             "type": "object",
             "title": "Agreements to deposit conditions",


### PR DESCRIPTION
It was decided that jhu will require a `$schema` property in the metadata blob.  As a result, this PR adds a required global `$schema` property that does _not_ appear in any form (i.e. Ember will need to add it, in order to create schema-valid metadata blobs"

See also #23