### PR TITLE
 Update NIHMS schema for nlmta or (some issn with pubType)

### DIFF
--- a/schemas/jhu/nihms.json
+++ b/schemas/jhu/nihms.json
@@ -25,12 +25,24 @@
         },
         "issn_present": {
             "type": "object",
-            "required": [
-                "issns"
-            ],
             "properties": {
                 "issns": {
-                    "$ref": "global.json#/properties/issns"
+                    "type": "array",
+                    "contains": {
+                        "type": "object",
+                        "required": [
+                            "issn",
+                            "pubType"
+                        ],
+                        "properties": {
+                            "issn": {
+                                "type": "string"
+                            },
+                            "pubType": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/testdata/invalid/no-nlmta-or-pubtype.json
+++ b/testdata/invalid/no-nlmta-or-pubtype.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://oa-pass.github.io/metadata-schemas/jhu/global.json",
+    "title": "The title of the article",
+    "journal-title": "A Terrific Journal",
+    "volume": "2",
+    "issue": "4",
+    "issns": [
+        {
+            "issn": "1234-5678"
+        },
+        {
+            "issn": "1234-5678x"
+        }
+    ],
+    "publisher": "Journal Publisher Inc",
+    "publicationDate": "2018",
+    "abstract": "This is the abstract of the article.",
+    "authors": [
+        {
+            "author": "Bob Author"
+        },
+        {
+            "author": "Jane Writer",
+            "orcid": "https://orcid.org/1234-5678-9087-4453"
+        }
+    ],
+    "under-embargo": "true",
+    "Embargo-end-date": "2019-01-18",
+    "agent_information": {
+        "name": "Chrome",
+        "version": "704583"
+    },
+    "agreements": {
+        "JScholarship": "This is the text I agreed to",
+        "NIHMS": "http://example.org/policies/nihms.html"
+    },
+    "doi": "10.123/foo.bar.xyz",
+    "journal-title-short": "ATJ"
+}

--- a/testdata/valid/nlmta-but-no-pubtype.json
+++ b/testdata/valid/nlmta-but-no-pubtype.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://oa-pass.github.io/metadata-schemas/jhu/global.json",
+    "title": "The title of the article",
+    "journal-title": "A Terrific Journal",
+    "volume": "2",
+    "issue": "4",
+    "issns": [
+        {
+            "issn": "1234-5678"
+        },
+        {
+            "issn": "1234-5678x"
+        }
+    ],
+    "publisher": "Journal Publisher Inc",
+    "publicationDate": "2018",
+    "abstract": "This is the abstract of the article.",
+    "authors": [
+        {
+            "author": "Bob Author"
+        },
+        {
+            "author": "Jane Writer",
+            "orcid": "https://orcid.org/1234-5678-9087-4453"
+        }
+    ],
+    "under-embargo": "true",
+    "Embargo-end-date": "2019-01-18",
+    "agent_information": {
+        "name": "Chrome",
+        "version": "704583"
+    },
+    "agreements": {
+        "JScholarship": "This is the text I agreed to",
+        "NIHMS": "http://example.org/policies/nihms.html"
+    },
+    "doi": "10.123/foo.bar.xyz",
+    "journal-NLMTA-ID": "atj",
+    "journal-title-short": "ATJ"
+}

--- a/testdata/valid/no-nlmta-but-has-a-pubtype.json
+++ b/testdata/valid/no-nlmta-but-has-a-pubtype.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://oa-pass.github.io/metadata-schemas/jhu/global.json",
+    "title": "The title of the article",
+    "journal-title": "A Terrific Journal",
+    "volume": "2",
+    "issue": "4",
+    "issns": [
+        {
+            "issn": "1234-5678",
+            "pubType": "Online"
+        },
+        {
+            "issn": "1234-5678x"
+        }
+    ],
+    "publisher": "Journal Publisher Inc",
+    "publicationDate": "2018",
+    "abstract": "This is the abstract of the article.",
+    "authors": [
+        {
+            "author": "Bob Author"
+        },
+        {
+            "author": "Jane Writer",
+            "orcid": "https://orcid.org/1234-5678-9087-4453"
+        }
+    ],
+    "under-embargo": "true",
+    "Embargo-end-date": "2019-01-18",
+    "agent_information": {
+        "name": "Chrome",
+        "version": "704583"
+    },
+    "agreements": {
+        "JScholarship": "This is the text I agreed to",
+        "NIHMS": "http://example.org/policies/nihms.html"
+    },
+    "doi": "10.123/foo.bar.xyz",
+    "journal-title-short": "ATJ"
+}


### PR DESCRIPTION
* NIHMS schema passes if a metadata blob contains an nlmta or _at least one_ issn contains a pubType.
  * This can be changed to _all_ issns contain a pubType by changing `contains` to `items` on line 31 of `schemas/jhu/nihms.json`. It is unclear which semantics match the assumptions being made by deposit services. 
* Added test schemas in `testdata/valid`, `testdata/invalid`, and enhanced validation test to verify expected passes or failures, due to the subtlety and complexity of this schema rule.

