### PR TITLE
Required author semantics and display

### DIFF
--- a/schemas/jhu/global.json
+++ b/schemas/jhu/global.json
@@ -65,7 +65,8 @@
                     "orcid": {
                         "type": "string"
                     }
-                }
+                },
+		"required": ["author"]
             }
         },
         "doi": {

--- a/schemas/jhu/jscholarship.json
+++ b/schemas/jhu/jscholarship.json
@@ -8,9 +8,6 @@
         "form": {
             "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
             "type": "object",
-            "required": [
-                "authors"
-            ],
             "properties": {
                 "authors": {
                     "$ref": "global.json#/properties/authors"


### PR DESCRIPTION
The schema is modified so that the author field is always required by the objects in an authors array.

In JScholarship, the required author is removed because it caused alpaca to display (required) twice and did not seem to do anything.

These changes do not address the requirement that the JScholarship authors array have at least one member.