### PR TITLE
Change publicationDate to a string, instead of a date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ script:
   - go build ./...
   - docker-compose build schemaservice
   - docker-compose pull fcrepo && docker-compose up -d && bash ./scripts/wait_for_docker.sh
-  - go test -v -tags=integration ./... || docker logs schemaservice 
+  - go test -v -tags=integration ./... || (docker logs schemaservice && exit 1) 
   - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ ! -z ${DOCKER_USERNAME+x} ]; then sh ./scripts/docker-push.sh; fi'

--- a/schemas/jhu/global.json
+++ b/schemas/jhu/global.json
@@ -129,7 +129,6 @@
         },
         "publicationDate": {
             "type": "string",
-            "format": "date",
             "title": "Publication Date",
             "description": "Publication date of the journal or article this manuscript was submitted to",
             "$comment": "This was formerly date-time format, but that appears too precise for values like 'Summer 2018'"


### PR DESCRIPTION
Now, arbitrary values such as "2018", "Fall '98", "Before society collapsed" will be schema valid with respect to `publicationDate`

Also fixes a big in `.travis.yml` which dumped the docker logs but did NOT fail the build when schema validation of test data fails.

Related to OA-PASS/pass-ember#964