### PR TITLE
Add the ability to merge schemas into a single union schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The schema service is an http service that accepts a list of PASS [repository](h
 For each repository, the schema service will retrieve the list of schemas relevant to the repository, place that list in the correct order (so
 that schemas that provide the most dependencies are displayed first), and resolves all `$ref` references that might appear in the schema.
 
+If a `merge` query parameter is provided (with any value, e.g. `?merge=true`), then all schemas will be merged into a single union schema.
+
 The result is an `application/json` response that contains a JSON list of schemas.
 
 ### building
@@ -119,6 +121,7 @@ The help page describes the possible commandline options.  Each option has a cor
         --username value, -u value  Username for basic auth to Fedora [$PASS_FEDORA_USER]
         --password value, -p value  Password for basic auth to Fedora [$PASS_FEDORA_PASSWORD]
         --port value                Port for the schema service http endpoint (default: 0) [$SCHEMA_SERVICE_PORT]
+        --merge, -m                 Always merge result schemas into a single one [$SCHEMA_SERVICE_MERGE]
 
 Command line options have a short form (`-i`) or a long form (`--internal`), which may be user interchangably.  For example, the following
 will run the schema service on port 8080, and user the username `myUser` and passeord `foo` for retrieving repository entities from the Fedora

--- a/lib/jsonschema/deref_test.go
+++ b/lib/jsonschema/deref_test.go
@@ -179,7 +179,7 @@ func parseSchema(t *testing.T, jsonString string) jsonschema.Instance {
 	instance := jsonschema.Instance(make(map[string]interface{}))
 	err := json.Unmarshal([]byte(jsonString), &instance)
 	if err != nil {
-		t.Fatalf("could not parse json: %+v", err)
+		t.Fatalf("could not parse json: %+v\n%s", err, jsonString)
 	}
 
 	return instance

--- a/lib/jsonschema/merge.go
+++ b/lib/jsonschema/merge.go
@@ -1,0 +1,92 @@
+package jsonschema
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+)
+
+// JSON schema fields that are ignorable for the sake of merging
+var ignorable = map[string]bool{"title": true, "description": true, "$id": true, "$schema": true, "$comment": true}
+
+// Merge merges multiple schema instances into a single one, folding in properties that do not
+// overlap, and
+func Merge(schemas []Instance) (Instance, error) {
+	var result mergeableMap = make(map[string]interface{})
+
+	for _, toMerge := range schemas {
+		for field, value := range toMerge {
+			if !ignorable[field] {
+				err := result.mergeIn(field, value)
+				if err != nil {
+					return nil, errors.Wrapf(err, "could not merge field '%s' from schema with ID '%s'", field, toMerge.ID())
+				}
+			}
+		}
+	}
+
+	return Instance(result), nil
+}
+
+// mergeableMap is a JSON map intended for merging in values
+type mergeableMap map[string]interface{}
+
+// mergeIn a value into a given field
+func (m mergeableMap) mergeIn(field string, value interface{}) error {
+	_, exists := m[field]
+
+	// Create empty map or array if none exists already, where appropriate
+	if !exists {
+		switch v := value.(type) {
+		case []interface{}:
+			m[field] = make([]interface{}, 0, len(v))
+		case map[string]interface{}:
+			m[field] = make(map[string]interface{}, len(v))
+		}
+	}
+
+	// Check for type clash
+	if m[field] != nil && reflect.TypeOf(m[field]) != reflect.TypeOf(value) {
+		return errors.Errorf("type conflict for property '%s': %s vs %s", field,
+			reflect.TypeOf(m[field]).Name(), reflect.TypeOf(value).Name())
+	}
+
+	// Now do the merge!
+	// For arrays, copy in values if they are novel
+	// For maps (JSON objects), merge each field
+	// For simple values, just copy
+	switch val := value.(type) {
+	case []interface{}:
+		for _, v := range val {
+			m[field] = addIfNotPresent(v, m[field].([]interface{}))
+		}
+	case map[string]interface{}:
+		existingMap := mergeableMap(m[field].(map[string]interface{}))
+		for k, v := range val {
+			err := existingMap.mergeIn(k, v)
+			if err != nil {
+				return errors.Wrapf(err, "could not merge into map at '%s'", field)
+			}
+		}
+	default:
+		if !ignorable[field] && m[field] != nil && m[field] != value {
+			return errors.Errorf("value conflict in property '%s': %s != %s", field, m[field], val)
+		}
+		m[field] = value
+	}
+
+	return nil
+}
+
+// Add to a slice only if a value doesn't exist
+func addIfNotPresent(value interface{}, container []interface{}) []interface{} {
+
+	for _, existing := range container {
+		if reflect.DeepEqual(existing, value) {
+			return container
+		}
+	}
+
+	// We don't need to defensively copy, as these are never mutated
+	return append(container, value)
+}

--- a/lib/jsonschema/merge_test.go
+++ b/lib/jsonschema/merge_test.go
@@ -1,0 +1,183 @@
+package jsonschema_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/OA-PASS/metadata-schemas/lib/jsonschema"
+	"github.com/go-test/deep"
+)
+
+func TestMerge(t *testing.T) {
+	cases := []struct {
+		name, expected string
+		schemas        []string
+	}{{
+		name: "simple ignore preamble",
+		schemas: []string{`{
+			"$schema": "http://example.org/schema",
+			"$id": "http://example.org/foo",
+			"title": "foo",
+			"description": "foo schema",
+			"$comment": "one",
+			"a": "1"
+		}`, `{
+			"$schema": "http://example.org/schema",
+			"$id": "http://example.org/bar",
+			"title": "bar",
+			"description": "bar schema",
+			"$comment": "two",
+			"b": "2"
+		}`},
+		expected: `{
+			"a": "1",
+			"b": "2"
+		}`,
+	}, {
+		name: "ignorable conflicts",
+		schemas: []string{`{
+			"a": {
+				"title": "A",
+				"description": "a letter",
+				"$comment": "displays good",
+				"type": "letter"
+			}
+		}`, `{
+			"a": {
+				"title": "a",
+				"description": "an awesome letter",
+				"$comment": "displays nicely",
+				"type": "letter"
+			}
+		}`},
+		expected: `{
+			"a": {
+				"title": "a",
+				"$comment": "displays nicely",
+				"description": "an awesome letter",
+				"type": "letter"
+			}
+		}`,
+	}, {
+		name: "simple array deduplication",
+		schemas: []string{`{
+			"array": ["a", "b", "c"]
+		}`, `{
+			"array": ["b", "c", "d"]
+		}`, `{
+			"array": ["c", "d", "e"]
+		}`},
+		expected: `{
+			"array": ["a", "b", "c", "d", "e"]
+		}`,
+	}, {
+		name: "complex array deduplication",
+		schemas: []string{`{
+			"array": [{"a": ["b", {"c": "d"}]}, "e"]
+		}`, `{
+			"array": [{"a": ["b", {"c": "d"}]}, "f"]
+		}`, `{
+			"array": ["e", "f", {"g": "h"}]
+		}`},
+		expected: `{
+			"array": [{"a": ["b", {"c": "d"}]}, "e", "f", {"g": "h"}]
+		}`,
+	}, {
+		name: "object merge",
+		schemas: []string{`{
+			"a": "b",
+			"c": ["d", "e"]
+		}`, `{
+			"a": "b",
+			"c": ["e", "f", "g"]
+		}`, `{
+			"h": {
+				"i": "j",
+				"k": ["l", "m"],
+				"n": {
+					"o": "p"
+				}
+			}
+		}`, `{
+			"h": {
+				"k": ["l", "m", "m'"],
+				"n": {
+					"q": "r"
+				}
+			}
+		}`},
+		expected: `{
+			"a": "b",
+			"c": ["d", "e", "f", "g"],
+			"h": {
+				"i": "j",
+				"k": ["l", "m", "m'"],
+				"n": {
+					"o": "p",
+					"q": "r"
+				}
+			}
+		}`,
+	}}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			var schemas []jsonschema.Instance
+			for _, s := range c.schemas {
+				schemas = append(schemas, parseSchema(t, s))
+			}
+
+			merged, err := jsonschema.Merge(schemas)
+			if err != nil {
+				t.Fatalf("Merging schemas failed: %+v", err)
+			}
+
+			if diffs := deep.Equal(merged, parseSchema(t, c.expected)); len(diffs) > 0 {
+				t.Fatalf("Result does not match expected: %s", strings.Join(diffs, "\n"))
+			}
+		})
+	}
+}
+
+func TestMergeErrors(t *testing.T) {
+	cases := map[string][]string{
+
+		"value conflict": {`{
+			"a": "b"
+		}`, `{
+			"a": "c"
+		}`},
+
+		"nested value conflict": {`{
+			"conflicting": {
+				"a": "b"
+			}
+		}`, `{
+			"conflicting": {
+				"a": "c"
+			}
+		}`},
+
+		"type conflict": {`{
+			"a": ["b", "c"]
+		}`, `{
+			"a": "e"
+		}`},
+	}
+
+	for name, schemas := range cases {
+		schemas := schemas
+		t.Run(name, func(t *testing.T) {
+			var toMerge []jsonschema.Instance
+			for _, s := range schemas {
+				toMerge = append(toMerge, parseSchema(t, s))
+			}
+
+			_, err := jsonschema.Merge(toMerge)
+			if err == nil {
+				t.Fatal("expected to see an error!")
+			}
+		})
+	}
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,4 +1,4 @@
-package metadata_schemas
+package metadata_schemas_test
 
 import (
 	"io/ioutil"
@@ -91,6 +91,13 @@ func loadSchemas(t *testing.T) jsonschema.Map {
 	if err != nil {
 		t.Fatalf("Error dereferencing schemas %+v", err)
 	}
+
+	// Finally, add a union schema that merges them all (making sure that validations are expected against that too)
+	merged, err := jsonschema.Merge(schemas)
+	if err != nil {
+		t.Fatalf("Error merging schemas: %+v", err)
+	}
+	schemaMap["merged"] = merged
 
 	return schemaMap
 }


### PR DESCRIPTION
Provides a `?merge=true` query parameter for requesting that all result schemas are merged into one on a per-request basis, as well as a `SCHEMA_SERVICE_MERGE` environment variable for forcing all responses to be merged.

## To test
It's probably easiest to try this out in pass-docker (or pass-ember), and see the effects.  Without an updated ember, you'd need to force all responses to be merged.  So, try the following:
* Build the schema service in this codebase via `docker-compose build`
* In `pass-docker` (or pass-ember, or wherever you are testing), change the schema service tag in `docker-compose.yml` to point to `:latest`
* in `.env`, add `SCHEMA_SERVICE_MERGE=true`
* start pass-docker or pass-ember (depending on where you're testing this) via docker-compose up -d
* Log in as `nih-user` and prepare a submission.  Be sure to select NIH-related grants
* Verify there is a single form page (ignore the title, as it's wrong!  I think there needs to be minor UI work to come up with an appropriate title for unified forms), and verify that `Journal-NLMTA-ID` is one of the fields.  It's nih-specific, and used to appear on its own page.

Provides implementation for #31 