### PR TITLE
Conditionally show Embargo-end-date field

### DIFF
--- a/schemas/jhu/common.json
+++ b/schemas/jhu/common.json
@@ -44,6 +44,9 @@
                     "$ref": "global.json#/properties/Embargo-end-date"
                 }
             },
+            "dependencies": {
+                "Embargo-end-date": ["under-embargo"]
+            },
             "options": {
                 "$ref": "global.json#/options"
             }

--- a/schemas/jhu/global.json
+++ b/schemas/jhu/global.json
@@ -150,6 +150,9 @@
             "description": "journal volume this article or manuscript was published in"
         }
     },
+    "dependencies": {
+        "Embargo-end-date": ["under-embargo"]
+    },
     "options": {
         "fields": {
             "title": {
@@ -269,7 +272,10 @@
                     "format": "MM/DD/YY",
                     "allowInputToggle": true
                 },
-                "order": 12
+                "order": 12,
+                "dependencies": {
+                    "under-embargo": true
+                }
             }
         }
     }


### PR DESCRIPTION
This addresses https://github.com/OA-PASS/pass-ember/issues/846

I don't know if there is a better way to specify the `Embargo-end-date` dependency in the common schema. We could simply use a `$ref` for the whole `dependencies` block, but that may limit dependencies that other schema may have. If there is no better way to reference the `Embargo-end-date` dependency, is it even worth having the dependency in the global schema?

Is this even necessary?