### PR TITLE
Require 'authors' property in J10P schema

### DIFF
--- a/schemas/jhu/jscholarship.json
+++ b/schemas/jhu/jscholarship.json
@@ -12,7 +12,8 @@
                 "authors": {
                     "$ref": "global.json#/properties/authors"
                 }
-            }
+            },
+            "required": ["authors"]
         },
         "options": {
             "$ref": "global.json#/options"


### PR DESCRIPTION
This will re-enable the validation checks for the presence of the `authors` property in J10P submissions. This requirement brings JSON schema validation logic back in line with intended behavior.